### PR TITLE
feat(typing): pause test when typing surface loses focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+
+- Pause the typing timer when the practice surface loses focus, then resume without counting away time.

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -223,6 +223,23 @@
     box-shadow: 0 0 0 4px var(--color-focus);
   }
 
+  .typing-surface.is-paused .typing-text {
+    @apply blur-sm;
+  }
+
+  .typing-paused-overlay {
+    @apply absolute inset-0 z-10 flex items-center justify-center;
+    background: color-mix(in srgb, var(--color-surface-strong) 55%, transparent);
+    backdrop-filter: blur(2px);
+  }
+
+  .typing-paused-hint {
+    @apply rounded-full border px-4 py-2 text-sm font-semibold uppercase tracking-[0.18em];
+    border-color: var(--color-accent-border);
+    background: var(--color-accent-soft);
+    color: var(--color-accent-hover);
+  }
+
   .help-chip {
     @apply rounded-full border px-3 py-1;
     border-color: var(--color-border);

--- a/app/javascript/controllers/typing_controller.js
+++ b/app/javascript/controllers/typing_controller.js
@@ -63,7 +63,15 @@ export default class extends Controller {
   }
 
   surfaceFocused() {
+    const wasPaused = this.session.paused
+    this.session.resume()
     this.hidePausedOverlay()
+
+    if (!wasPaused) return
+
+    this.startTicker()
+    this.render()
+    if (this.session.shouldFinish()) this.finishSession()
   }
 
   showPausedOverlay() {

--- a/app/javascript/controllers/typing_controller.js
+++ b/app/javascript/controllers/typing_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
     "durationButton",
     "fastRacer",
     "helpOverlay",
+    "pausedOverlay",
     "progress",
     "results",
     "resultDetails",
@@ -52,6 +53,29 @@ export default class extends Controller {
     this.typingSurfaceTarget.focus()
   }
 
+  surfaceBlurred() {
+    if (!this.session.started || this.session.finished || this.session.paused) return
+
+    this.session.pause()
+    this.stopTicker()
+    this.showPausedOverlay()
+    this.render()
+  }
+
+  surfaceFocused() {
+    this.hidePausedOverlay()
+  }
+
+  showPausedOverlay() {
+    this.pausedOverlayTarget.classList.remove("hidden")
+    this.typingSurfaceTarget.classList.add("is-paused")
+  }
+
+  hidePausedOverlay() {
+    this.pausedOverlayTarget.classList.add("hidden")
+    this.typingSurfaceTarget.classList.remove("is-paused")
+  }
+
   setDuration(event) {
     this.durationSeconds = Number(event.params.duration)
     this.resetSession()
@@ -86,6 +110,7 @@ export default class extends Controller {
     if (event.key.length !== 1 || event.altKey) return
 
     event.preventDefault()
+    this.hidePausedOverlay()
     this.session.type(event.key.toLowerCase())
     this.startTicker()
     this.render()
@@ -153,6 +178,7 @@ export default class extends Controller {
 
   resetSession() {
     this.stopTicker()
+    this.hidePausedOverlay()
     this.resultsTarget.classList.add("hidden")
     this.session = new TypingSessionState({ excerpt: this.currentExcerpt, durationSeconds: this.durationSeconds })
     this.lastScrolledLineTop = null
@@ -187,6 +213,7 @@ export default class extends Controller {
 
   finishSession() {
     this.stopTicker()
+    this.hidePausedOverlay()
     const result = this.session.finish()
     SessionStore.save(result)
     this.render()
@@ -204,7 +231,7 @@ export default class extends Controller {
     this.timeLeftTarget.textContent = this.session.remainingSeconds
     this.progressTarget.textContent = `${this.session.cursor}/${this.session.targetText.length}`
     this.sourceTarget.textContent = `${this.currentExcerpt.title} · ${this.currentExcerpt.author}`
-    this.stateLabelTarget.textContent = this.session.finished ? this.i18nValue.states.complete : this.session.started ? this.i18nValue.states.typing : this.i18nValue.states.ready
+    this.stateLabelTarget.textContent = this.session.finished ? this.i18nValue.states.complete : this.session.paused ? this.i18nValue.states.paused : this.session.started ? this.i18nValue.states.typing : this.i18nValue.states.ready
     const digraphSummary = this.session.finished ? this.session.digraphSummary() : emptyDigraphSummary()
     this.textTarget.replaceChildren(...this.characterSpans(digraphSummary))
     this.renderSlowPairs(digraphSummary)

--- a/app/javascript/lib/typing/session_state.js
+++ b/app/javascript/lib/typing/session_state.js
@@ -64,10 +64,11 @@ export class TypingSessionState {
   }
 
   resume(now = performance.now()) {
-    if (!this.paused) return
+    if (!this.paused) return false
 
     this.pausedMs += now - this.pausedAtPerformance
     this.pausedAtPerformance = null
+    return true
   }
 
   type(character, now = performance.now()) {
@@ -89,6 +90,7 @@ export class TypingSessionState {
   backspace(now = performance.now()) {
     if (!this.started || this.finished || this.cursor === 0) return
 
+    this.resume(now)
     const index = this.cursor - 1
     const elapsedMs = Math.round(now - this.startedAtPerformance - this.pausedSoFar(now))
     this.keyEvents.push({ action: "backspace", index, elapsedMs })

--- a/app/javascript/lib/typing/session_state.js
+++ b/app/javascript/lib/typing/session_state.js
@@ -11,6 +11,8 @@ export class TypingSessionState {
     this.startedAtEpoch = null
     this.startedAtPerformance = null
     this.finishedAtEpoch = null
+    this.pausedMs = 0
+    this.pausedAtPerformance = null
   }
 
   get started() {
@@ -19,6 +21,10 @@ export class TypingSessionState {
 
   get finished() {
     return this.finishedAtEpoch !== null
+  }
+
+  get paused() {
+    return this.pausedAtPerformance !== null
   }
 
   get cursor() {
@@ -32,11 +38,16 @@ export class TypingSessionState {
   get elapsedMs() {
     if (!this.started) return 0
     const end = this.finishedAtEpoch ? this.finishedAtPerformance : performance.now()
-    return Math.max(0, end - this.startedAtPerformance)
+    return Math.max(0, end - this.startedAtPerformance - this.pausedSoFar(end))
   }
 
   get remainingSeconds() {
     return Math.max(0, Math.ceil(this.durationSeconds - (this.elapsedMs / 1000)))
+  }
+
+  pausedSoFar(now = performance.now()) {
+    const ongoing = this.pausedAtPerformance !== null ? now - this.pausedAtPerformance : 0
+    return this.pausedMs + ongoing
   }
 
   start(now = performance.now()) {
@@ -46,15 +57,29 @@ export class TypingSessionState {
     this.startedAtPerformance = now
   }
 
+  pause(now = performance.now()) {
+    if (!this.started || this.finished || this.paused) return
+
+    this.pausedAtPerformance = now
+  }
+
+  resume(now = performance.now()) {
+    if (!this.paused) return
+
+    this.pausedMs += now - this.pausedAtPerformance
+    this.pausedAtPerformance = null
+  }
+
   type(character, now = performance.now()) {
     this.start(now)
+    this.resume(now)
 
     if (this.finished || this.cursor >= this.targetText.length) return
 
     const index = this.cursor
     const expected = this.targetText[index]
     const correct = character === expected
-    const elapsedMs = Math.round(now - this.startedAtPerformance)
+    const elapsedMs = Math.round(now - this.startedAtPerformance - this.pausedSoFar(now))
 
     this.typedCharacters.push(character)
     this.keyEvents.push({ action: "type", index, expected, actual: character, correct, elapsedMs })
@@ -65,7 +90,7 @@ export class TypingSessionState {
     if (!this.started || this.finished || this.cursor === 0) return
 
     const index = this.cursor - 1
-    const elapsedMs = Math.round(now - this.startedAtPerformance)
+    const elapsedMs = Math.round(now - this.startedAtPerformance - this.pausedSoFar(now))
     this.keyEvents.push({ action: "backspace", index, elapsedMs })
     this.typedCharacters.pop()
     this.characterTimings = this.characterTimings.filter((timing) => timing.index !== index)

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -45,10 +45,13 @@
       type="button"
       class="typing-surface"
       data-typing-target="typingSurface"
-      data-action="click->typing#focus keydown->typing#keydown"
+      data-action="click->typing#focus keydown->typing#keydown blur->typing#surfaceBlurred focus->typing#surfaceFocused"
       tabindex="0"
       aria-label="<%= t("pages.practice.typing_area_label") %>"
     >
+      <span class="typing-paused-overlay hidden" data-typing-target="pausedOverlay" aria-hidden="true">
+        <span class="typing-paused-hint"><%= t("pages.practice.paused_hint") %></span>
+      </span>
       <span class="text-subtle mb-8 flex flex-wrap items-center justify-between gap-3 text-xs sm:text-sm">
         <span data-typing-target="source"></span>
         <span class="help-chip"><%= t("pages.practice.help_hint") %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
         time: "time"
         chars: "chars"
       state_ready: "click here and start typing"
+      paused_hint: "click to resume"
       typing_area_label: "Typing practice area"
       help_hint: "? help · Esc restart · Tab new text"
       slow_combinations: "Slow combinations"
@@ -86,6 +87,7 @@ en:
         complete: "complete"
         typing: "typing"
         ready: "click here and start typing"
+        paused: "paused"
       result:
         accuracy: "accuracy"
         keystrokes_captured: "keystrokes captured"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -30,6 +30,7 @@ pt-BR:
         time: "tempo"
         chars: "caracs."
       state_ready: "clique aqui e comece a digitar"
+      paused_hint: "clique para continuar"
       typing_area_label: "Área de prática de digitação"
       help_hint: "? ajuda · Esc reinicia · Tab novo texto"
       slow_combinations: "Combinações lentas"
@@ -86,6 +87,7 @@ pt-BR:
         complete: "completo"
         typing: "digitando"
         ready: "clique aqui e comece a digitar"
+        paused: "pausado"
       result:
         accuracy: "de precisão"
         keystrokes_captured: "teclas registradas"

--- a/test/javascript/session_state.test.mjs
+++ b/test/javascript/session_state.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import test from "node:test"
+
+test("TypingSessionState excludes paused time from elapsed metrics", async () => {
+  const { TypingSessionState } = await loadSessionState()
+  const session = new TypingSessionState({ excerpt: excerpt("abc"), durationSeconds: 30 })
+
+  session.type("a", 1000)
+  session.pause(4000)
+
+  withPerformanceNow(9000, () => {
+    assert.equal(session.paused, true)
+    assert.equal(session.elapsedMs, 3000)
+  })
+
+  session.type("b", 9000)
+
+  assert.equal(session.paused, false)
+  withPerformanceNow(9000, () => {
+    assert.equal(session.elapsedMs, 3000)
+  })
+  withPerformanceNow(10000, () => {
+    assert.equal(session.elapsedMs, 4000)
+  })
+  assert.equal(session.characterTimings[1].elapsedMs, 3000)
+})
+
+test("TypingSessionState resumes when backspacing after a pause", async () => {
+  const { TypingSessionState } = await loadSessionState()
+  const session = new TypingSessionState({ excerpt: excerpt("ab"), durationSeconds: 30 })
+
+  session.type("a", 1000)
+  session.type("b", 1500)
+  session.pause(2000)
+  session.backspace(7000)
+
+  assert.equal(session.paused, false)
+  assert.equal(session.cursor, 1)
+  assert.equal(session.keyEvents.at(-1).action, "backspace")
+  assert.equal(session.keyEvents.at(-1).elapsedMs, 1000)
+})
+
+test("TypingSessionState freezes remaining seconds while paused", async () => {
+  const { TypingSessionState } = await loadSessionState()
+  const session = new TypingSessionState({ excerpt: excerpt("abc"), durationSeconds: 10 })
+
+  session.type("a", 1000)
+  session.pause(4000)
+
+  withPerformanceNow(24000, () => {
+    assert.equal(session.remainingSeconds, 7)
+  })
+
+  session.resume(24000)
+  withPerformanceNow(24000, () => {
+    assert.equal(session.remainingSeconds, 7)
+  })
+})
+
+function excerpt(normalizedText) {
+  return {
+    id: "test-excerpt",
+    title: "Test excerpt",
+    author: "Test author",
+    source: "Test source",
+    normalized_text: normalizedText
+  }
+}
+
+async function loadSessionState() {
+  const sourcePath = new URL("../../app/javascript/lib/typing/session_state.js", import.meta.url)
+  const metricsPath = new URL("../../app/javascript/lib/typing/metrics.js", import.meta.url)
+  const source = await readFile(sourcePath, "utf8")
+  const tempDirectory = await mkdtemp(join(tmpdir(), "frank-type-session-state-"))
+  const modulePath = join(tempDirectory, "session_state.mjs")
+  const rewrittenSource = source.replace('from "lib/typing/metrics"', `from ${JSON.stringify(metricsPath.href)}`)
+
+  await writeFile(modulePath, rewrittenSource)
+
+  try {
+    return await import(pathToFileURL(modulePath).href)
+  } finally {
+    await rm(tempDirectory, { force: true, recursive: true })
+  }
+}
+
+function withPerformanceNow(now, callback) {
+  const originalPerformance = globalThis.performance
+  globalThis.performance = { now: () => now }
+
+  try {
+    callback()
+  } finally {
+    globalThis.performance = originalPerformance
+  }
+}


### PR DESCRIPTION
Track and subtract away-time so the wall-clock timer freezes on blur and resumes on the next keystroke, with a dimmed "click to resume" overlay.